### PR TITLE
refactor-: Refactor To Get WebPack To Build Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "main": "server.js",
   "scripts": {
     "clean": "rm -rf build node_modules && npm install",
-    "build:dev": "webpack --display-error-details --config webpack/webpack.dev.babel.js && babel source/server --out-dir build/server --config ./.babelrc && cp server.* build/server",
-    "build:prod": "webpack --display-error-details --config webpack/webpack.prod.babel.js && babel source/server --out-dir build/server --config ./.babelrc && cp server.* build/server",
-    "start": "node build/server/server",
-    "all:dev": "npm run clean && npm run build:dev && npm run start",
-    "all:prod": "npm run clean && npm run build:prod && npm run start",
-    "precommit": "eslint eslint --ext .jsx --ext .js source webpack"
+    "prepush": "eslint eslint --ext .jsx --ext .js source webpack",
+    "build:dev": "webpack --display-error-details --config webpack/webpack.dev.babel.js",
+    "build:prod": "webpack --display-error-details --config webpack/webpack.prod.babel.js",
+    "run:dev": "node build/server/server",
+    "run:prod": "node build/server/server.min",
+    "all:dev": "npm run clean && npm run build:dev && npm run run:dev",
+    "all:prod": "npm run clean && npm run build:prod && npm run run:prod"
   },
   "engines": {
     "node": "8.9.1",

--- a/source/server/server.js
+++ b/source/server/server.js
@@ -1,16 +1,17 @@
 import express from 'express'
 import http2Server from 'spdy'
-import path from 'path'
 import fs from 'fs'
 
 // Tell Express to create a basic HTTP server
 const httpServer = express()
 
-// Tell Express which directory to use to serve files from
-httpServer.use(express.static(path.join(__dirname, '..', 'client')))
+// Tell Express which directory to use to serve static assets from
+const clientFolder = `${process.env.BUILD_FOLDER}/client`
+httpServer.use(express.static(clientFolder))
 
-// Tell Express to redirect all requests back to the default route
-httpServer.get('*', (request, response) => response.redirect('/'))
+// Tell Express to redirect all requests back to the index file
+const indexFile = `${clientFolder}/index.html`
+httpServer.get('*', (request, response) => response.sendFile(indexFile))
 
 // Pull off environment variable values passed in to this process using object destructuring
 const {

--- a/webpack/webpack.dev.babel.js
+++ b/webpack/webpack.dev.babel.js
@@ -1,15 +1,15 @@
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
-import { EnvironmentPlugin } from 'webpack'
+import webpack from 'webpack'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
-
+import fs from 'fs'
 import path from 'path'
 
-const config = {
+const clientConfig = {
   devtool: 'source-map',
   entry: './source/client/application/application.jsx',
   output: {
     path: path.join(__dirname, '..', 'build', 'client'),
-    filename: './bundle.js'
+    filename: './client.js'
   },
   module: {
     rules: [
@@ -25,20 +25,48 @@ const config = {
     ]
   },
   plugins: [
-    new EnvironmentPlugin({
-      NODE_ENV: 'development', // use 'development' unless process.env.NODE_ENV is defined
-      BABEL_ENV: 'development', // use 'development' unless process.env.BABEL_ENV is defined
-      DEBUG: true
-    }),
-    new ExtractTextPlugin('./bundle.css'),
+    new ExtractTextPlugin('./client.css'),
     new HtmlWebpackPlugin({
       title: 'Todos',
       template: './source/client/application/index.html'
     })
   ],
+  target: 'web',
   resolve: {
     extensions: ['.js', '.jsx', '.css', '.scss'],
   }
 }
 
-export default config
+const nodeModules = fs.readdirSync('node_modules')
+  .filter((filePath) => !filePath.includes('.bin'))
+  .map((filePath) => `commonjs ${filePath}`)
+
+const serverConfig = {
+  entry: './source/server/server.js',
+  output: {
+    path: path.join(__dirname, '..', 'build', 'server'),
+    filename: './server.js'
+  },
+  devtool: 'eval',
+  module: {
+    rules: [
+      {
+        test: /\.(js?)$/,
+        exclude: [/node_modules/, /build/],
+        use: 'babel-loader'
+      }
+    ]
+  },
+  plugins: [
+    new webpack.EnvironmentPlugin({
+      BUILD_FOLDER: path.resolve(__dirname, '..', 'build')
+    }),
+  ],
+  target: 'node',
+  resolve: {
+    extensions: ['.js'],
+  },
+  externals: [nodeModules]
+}
+
+export default [clientConfig, serverConfig]

--- a/webpack/webpack.prod.babel.js
+++ b/webpack/webpack.prod.babel.js
@@ -1,14 +1,14 @@
 import ExtractTextPlugin from 'extract-text-webpack-plugin'
 import webpack from 'webpack'
 import HtmlWebpackPlugin from 'html-webpack-plugin'
-
+import fs from 'fs'
 import path from 'path'
 
-const config = {
+const clientConfig = {
   entry: './source/client/application/application.jsx',
   output: {
     path: path.join(__dirname, '..', 'build', 'client'),
-    filename: './bundle.min.js'
+    filename: './client.min.js'
   },
   module: {
     rules: [
@@ -24,20 +24,48 @@ const config = {
     ]
   },
   plugins: [
-    new webpack.EnvironmentPlugin({
-      NODE_ENV: 'production', // use 'development' unless process.env.NODE_ENV is defined
-      BABEL_ENV: 'production', // use 'development' unless process.env.BABEL_ENV is defined
-      DEBUG: false
-    }),
-    new ExtractTextPlugin('./bundle.css'),
+    new ExtractTextPlugin('./client.min.css'),
     new HtmlWebpackPlugin({
       title: 'Todos',
       template: './source/client/application/index.html'
     })
   ],
+  target: 'web',
   resolve: {
     extensions: ['.js', '.jsx', '.css', '.scss'],
   }
 }
 
-export default config
+const nodeModules = fs.readdirSync('node_modules')
+  .filter((filePath) => !filePath.includes('.bin'))
+  .map((filePath) => `commonjs ${filePath}`)
+
+const serverConfig = {
+  entry: './source/server/server.js',
+  output: {
+    path: path.join(__dirname, '..', 'build', 'server'),
+    filename: './server.min.js'
+  },
+  devtool: 'eval',
+  module: {
+    rules: [
+      {
+        test: /\.(js?)$/,
+        exclude: [/node_modules/, /build/],
+        use: 'babel-loader'
+      }
+    ]
+  },
+  plugins: [
+    new webpack.EnvironmentPlugin({
+      BUILD_FOLDER: path.resolve(__dirname, '..', 'build')
+    }),
+  ],
+  target: 'node',
+  resolve: {
+    extensions: ['.js'],
+  },
+  externals: [nodeModules]
+}
+
+export default [clientConfig, serverConfig]


### PR DESCRIPTION
It seemed strange to use webpack to build the client code and babel to build the server code.
So now we use webpack to build both client and server code.